### PR TITLE
Send user locales to discourse

### DIFF
--- a/lang/en/local_discoursesso.php
+++ b/lang/en/local_discoursesso.php
@@ -24,6 +24,8 @@
 
 $string['discourseurllabel'] = 'Discourse URL';
 $string['discourseurlhelp'] = 'The URL of your Discourse instance, i.e. \'https://meta.discourse.org\'.';
+$string['localelabel'] = 'Sync user locale?';
+$string['localehelp'] = 'This setting will send a user\'s locale in Moodle to the Discourse server on log in. This will change the user\'s language in Discourse to match their language in Moodle.';
 $string['modulename'] = 'Discourse SSO';
 $string['modulename_help'] = 'A plugin to use Moodle as a SSO provider for Discourse.';
 $string['modulenameplural'] = 'Discourse SSOs';

--- a/locallib.php
+++ b/locallib.php
@@ -54,7 +54,7 @@ function get_discourse_locale($moodleuserlang) {
             $discourselocale = "zh_TW";
             break;
          default:
-            $discourselocale = preg_replace('~_[a-zA-Z]{2}~s', '', $moodleuserlang);
+            $discourselocale = preg_replace('~(_[a-zA-Z0-9]+)+~s', '', $moodleuserlang);
     }
     return $discourselocale;
 }

--- a/locallib.php
+++ b/locallib.php
@@ -23,3 +23,39 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
 */
 
+function get_discourse_locale($moodleuserlang) {
+    switch ($moodleuserlang) {
+        // For these specific locales, map to Moodle's lang code.
+        // For everything else, cut off anything after underscore ie
+        // es_mx and es_co will return es.
+        // TODO: Moodle has A LOT more languages than Discourse... how to handle those?
+        case "bs":
+            $discourselocale = "bs_BA";
+            break;
+        case "fa":
+            $discourselocale = "fa_IR";
+            break;
+        case "no":
+            $discourselocale = "nb_NO";
+            break;
+        case "pl":
+            $discourselocale = "pl_PL";
+            break;
+        case "pt_br":
+            $discourselocale = "pt_BR";
+            break;
+        case "tr":
+            $discourselocale = "tr_TR";
+            break;
+        case "zh_cn":
+            $discourselocale = "zh_CN";
+            break;
+        case "zh_tw":
+            $discourselocale = "zh_TW";
+            break;
+         default:
+            $discourselocale = preg_replace('~_[a-zA-Z]{2}~s', '', $moodleuserlang);
+    }
+    return $discourselocale;
+}
+

--- a/locallib.php
+++ b/locallib.php
@@ -1,0 +1,25 @@
+<?php
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * local_discoursesso
+ *
+ *
+ * @package    local
+ * @subpackage discoursesso
+ * @copyright  2019 Saylor Academy
+ * @author     John Azinheira
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+*/
+

--- a/settings.php
+++ b/settings.php
@@ -43,5 +43,11 @@ if ( $hassiteconfig ){
 	$settings->add(
 		new admin_setting_configtext('discoursesso_discourse_url', get_string('discourseurllabel', 'local_discoursesso'), get_string('discourseurlhelp', 'local_discoursesso'), 'https://discourse.example', PARAM_TEXT)
 	);
+
+	$name = 'local_discoursesso/locale';
+    $label = get_string('localelabel', 'local_discoursesso');
+    $help = get_string('localehelp', 'local_discoursesso');
+    $setting = new admin_setting_configcheckbox($name, $label, $help, 1);
+    $settings->add($setting);
  
 }

--- a/sso.php
+++ b/sso.php
@@ -24,7 +24,7 @@
 */
 
 require_once('../../config.php');
-
+require_once('./locallib.php');
 require_once __DIR__ . '/vendor/discourse-php/src/SSOHelper.php';
 
 global $CFG, $DB, $USER;

--- a/sso.php
+++ b/sso.php
@@ -101,9 +101,9 @@ $user = $DB->get_record('user', array('id' => $USER->id));
 $userdescription = format_text($user->description, $user->descriptionformat);
 
 $extraparams = array(
-    'username' => $USER->username,
-    'name'     => fullname($USER, true),
-    'bio'      => $userdescription
+    'username'      => $USER->username,
+    'name'          => fullname($USER, true),
+    'bio'           => $userdescription
 );
 
 // Generate user avatar url
@@ -117,6 +117,14 @@ if (($userpicture->user->picture > 0) || !empty($CFG->enablegravatar)) {
 if (isset($useravatar)) {
     $extraparams['avatar_url'] = $useravatar;
     $extraparams['avatar_force_update'] = 'true';
+}
+
+// Get the user's locale after converting, if enabled.
+if (get_config('local_discoursesso', 'locale')) {
+    $discourselocale = get_discourse_locale($user->lang);
+
+    $extraparams['locale'] = $discourselocale;
+    $extraparams['locale_force_update'] = 'true';
 }
 
 // Build query string and redirect back to the Discourse site.

--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2017112800;
+$plugin->version  = 2019041100;
 $plugin->requires = 2016052306;  // Requires this Moodle version - at least 3.1
 $plugin->cron     = 0;
 $plugin->component = 'local_discoursesso';
 
-$plugin->release = '1.0.1';
+$plugin->release = '1.1.0';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
When enabled in plugin settings, send the user's language setting (locale) to discourse.