### PR TITLE
Add instruction to check 'enable sso' in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The plugin needs to be set up on both the Moodle side and the Discourse side. Th
 1. Navigate to the Discourse admin dashboard and go to Settings->Login.
 2. Under the 'sso url' setting enter in "{your-moodle-url}/local/discoursesso/sso.php" substituting the base url of your Moodle installation for {your-moodle-url}.
 3. Under the 'sso secret' setting enter in the previously generated secret.
+4. Check 'enable sso'.
 Optional:
     The following settings are optional and may be checked:
         1. sso overrides bio


### PR DESCRIPTION
The 'enable sso' checkbox must be enabled in Discourse for this to work but this was missing from the readme. Now added.