### PR TITLE
Feat/sync cohorts

### DIFF
--- a/db/events.php
+++ b/db/events.php
@@ -33,4 +33,18 @@ $observers = array(
         'callback' => 'local_discoursesso_cohort_deleted_handler',
         'internal' => false
     ),
+    // Listen for when a user is added to a cohort.
+        array(
+        'eventname' => '\core\event\cohort_member_added',
+        'includefile' => '/local/discoursesso/locallib.php',
+        'callback' => 'local_discoursesso_cohort_member_added_handler',
+        'internal' => false
+    ),
+    // Listen for when a user is removed from a cohort.
+        array(
+        'eventname' => '\core\event\cohort_member_removed',
+        'includefile' => '/local/discoursesso/locallib.php',
+        'callback' => 'local_discoursesso_cohort_member_removed_handler',
+        'internal' => false
+    ),
 );

--- a/vendor/discourse-api-php/lib/DiscourseAPI.php
+++ b/vendor/discourse-api-php/lib/DiscourseAPI.php
@@ -258,6 +258,54 @@ class DiscourseAPI
     }
 
     /**
+     * addGroupMembers
+     *
+     * @param string $group         name of group
+     * @param array $usernames      array of users to add
+     * @return mixed HTTP return code and API return object
+     */
+
+    function addGroupMembers($group, array $usernames)
+    {
+        $obj = $this->_getRequest('/groups/' . $name . '.json');
+        if ($obj->http_code != 200) {
+            return false;
+        }
+
+        $groupId = $obj->apiresult->id;
+
+        $params = array(
+            'usernames' => implode(',', $usernames)
+        );
+
+        return $this->_putRequest("/groups/{$groupId}/members.json", $params);
+    }
+
+    /**
+     * removeGroupMembers
+     *
+     * @param string $group         name of group
+     * @param array $usernames      array of users to remove
+     * @return mixed HTTP return code and API return object
+     */
+
+    function removeGroupMembers($group, array $usernames)
+    {
+        $obj = $this->_getRequest('/groups/' . $name . '.json');
+        if ($obj->http_code != 200) {
+            return false;
+        }
+
+        $groupId = $obj->apiresult->id;
+
+        $params = array(
+            'usernames' => implode(',', $usernames)
+        );
+
+        return $this->_deleteRequest("/groups/{$groupId}/members.json", $params);
+    }
+
+    /**
      * createUser
      *
      * @param string $name         name of new user

--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2020042400;
+$plugin->version  = 2022080100;
 $plugin->requires = 2016052306;  // Requires this Moodle version - at least 3.1
 $plugin->cron     = 0;
 $plugin->component = 'local_discoursesso';
 
-$plugin->release = '1.4.0';
+$plugin->release = '1.5.0';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
This PR adds functionality to the plugin to monitor when members are added or removed from cohorts; if the cohort is one that is synced with Discourse, the user is added/removed from the corresponding group on Discourse.

This is done in order to make the student experience smoother if the Discourse site is using groups to do things like hiding or gating topics. Currently, the student would have to log out and then log back into Discourse to refresh their group memberships.